### PR TITLE
Switch to rb-sys to compile native extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Run tests
         run: cargo test --verbose
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ruby: ["3.0", "3.4"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         ruby: ["3.0", "3.4"]
     steps:
       - uses: actions/checkout@v6.0.2
@@ -36,3 +36,15 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Run Ruby extension smoke tests
         run: bundle exec rake test
+
+  windows_cross_build:
+    name: Cross-build Windows native gem
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Cross-build x64-mingw-ucrt gem
+        run: bundle exec rb-sys-dock --platform x64-mingw-ucrt --build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ jobs:
     name: Build source gem
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.4
           bundler-cache: true
       - run: bundle exec rake build
       - name: Upload source gem
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: source-gem
           path: pkg/*.gem
@@ -36,7 +36,7 @@ jobs:
           - arm64-darwin
           - x64-mingw-ucrt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.4
@@ -44,7 +44,7 @@ jobs:
       - name: Build native gems
         run: bundle exec rb-sys-dock --platform ${{ matrix.platform }} --build
       - name: Upload native gems
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: native-gem-${{ matrix.platform }}
           path: pkg/*-${{ matrix.platform }}.gem
@@ -67,7 +67,7 @@ jobs:
           echo "GEM_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,81 +3,67 @@ on:
   push:
     tags:
       - "[0-9]*.[0-9]*.[0-9]*"
+      - "v[0-9]*.[0-9]*.[0-9]*"
 
 jobs:
-  build_gem:
+  build_source_gem:
     name: Build source gem
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby-pkgs@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.4
-      - run: sudo apt-get update
-      - run: gem update --system
-      - run: rake gem
+          bundler-cache: true
+      - run: bundle exec rake build
       - name: Upload source gem
         uses: actions/upload-artifact@v4
         with:
-          name: distributing_iterator.gem
+          name: source-gem
           path: pkg/*.gem
           retention-days: 1
 
-  compile_native_gems:
-    name: Compile native gem
-    needs: build_gem
+  build_native_gems:
+    name: Build native gem (${{ matrix.platform }})
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-24.04
-            platform: x86_64-linux
-            ruby: "3.4"
-          - os: ubuntu-24.04-arm
-            platform: aarch64-linux
-            ruby: "3.4"
-          - os: macos-latest
-            platform: arm64-darwin
-            ruby: "3.4"
-    runs-on: ${{ matrix.os }}
+        platform:
+          - x86_64-linux
+          - aarch64-linux
+          - x86_64-darwin
+          - arm64-darwin
+          - x64-mingw-ucrt
     steps:
       - uses: actions/checkout@v4
-
-      - uses: ruby/setup-ruby-pkgs@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
-
-      - name: Install gem-compiler
-        run: gem install gem-compiler
-
-      - name: Download source gem
-        uses: actions/download-artifact@v4
-        with:
-          name: distributing_iterator.gem
-          path: pkg/
-
-      - name: Compile gem
-        run: |
-          SOURCE_GEM=$(ls pkg/*.gem | grep -v -- '-x86_64-linux\|aarch64-linux\|arm64-darwin')
-          gem compile $SOURCE_GEM --prune
-
-      - name: Upload compiled gem
+          ruby-version: 3.4
+          bundler-cache: true
+      - name: Build native gems
+        run: bundle exec rb-sys-dock --platform ${{ matrix.platform }} --build
+      - name: Upload native gems
         uses: actions/upload-artifact@v4
         with:
-          name: distributing_iterator-${{ matrix.platform }}.gem
-          path: ./*.gem
+          name: native-gem-${{ matrix.platform }}
+          path: pkg/*-${{ matrix.platform }}.gem
           retention-days: 1
 
   release:
     name: Create GitHub Release
-    needs: compile_native_gems
+    needs:
+      - build_source_gem
+      - build_native_gems
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-
       - name: Extract version
         id: extract_version
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
           echo "GEM_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Download all artifacts
@@ -85,24 +71,10 @@ jobs:
         with:
           path: artifacts
 
-      - name: Rename gem files with version
-        run: |
-          mkdir -p release_gems
-          for gem in artifacts/distributing_iterator-*.gem/*.gem; do
-            # Extract platform from the original filename
-            platform=$(basename $gem | sed -E 's/distributing_iterator-([^-]+-[^-]+)\.gem/\1/')
-            
-
-            target_filename="distributing_iterator-${GEM_VERSION}-${platform}.gem"
-            target_path="release_gems/$target_filename"
-            mv "$gem" "$target_path"
-          done
-          # Move source gem to release_gems directory
-          mv artifacts/distributing_iterator.gem/*.gem release_gems/distributing_iterator-${GEM_VERSION}.gem
-
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.GEM_VERSION }}
-          files: release_gems/*.gem
+          tag_name: ${{ github.ref_name }}
+          name: distributing_iterator ${{ env.GEM_VERSION }}
+          files: artifacts/**/*.gem
           generate_release_notes: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on:
   push:
@@ -10,13 +10,29 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  rust:
+    name: Rust
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Run tests
+        run: cargo test --verbose
+
+  ruby_extension:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        ruby: ["3.0", "3.4"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Run Ruby extension smoke tests
+        run: bundle exec rake test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@
 # will have compiled files and executables
 debug/
 target/
+tmp/
+ext/distributing_iterator/Makefile
+ext/distributing_iterator/mkmf.log
+ext/distributing_iterator/.sitearchdir.time
+lib/distributing_iterator/distributing_iterator.bundle
+lib/distributing_iterator/distributing_iterator.so
+lib/distributing_iterator/distributing_iterator.dll
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
@@ -14,3 +21,4 @@ target/
 *.pdb
 
 pkg/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ lib/distributing_iterator/distributing_iterator.dll
 
 pkg/
 .DS_Store
+Gemfile.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "distributing-iterator"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "magnus"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d87ae53030f3a22e83879e666cb94e58a7bdf31706878a0ba48752994146dab"
+checksum = "3b36a5b126bbe97eb0d02d07acfeb327036c6319fd816139a49824a83b7f9012"
 dependencies = [
  "magnus-macros",
  "rb-sys",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "magnus-macros"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
+checksum = "47607461fd8e1513cb4f2076c197d8092d921a1ea75bd08af97398f593751892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -510,18 +510,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.111"
+version = "0.9.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becea799ce051c16fb140be80f5e7cf781070f99ca099332383c2b17861249af"
+checksum = "c85c4188462601e2aa1469def389c17228566f82ea72f137ed096f21591bc489"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.111"
+version = "0.9.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64691175abc704862f60a9ca8ef06174080cc50615f2bf1d4759f46db18b4d29"
+checksum = "568068db4102230882e6d4ae8de6632e224ca75fe5970f6e026a04e91ed635d3"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-env"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
+checksum = "cca7ad6a7e21e72151d56fe2495a259b5670e204c3adac41ee7ef676ea08117a"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Fetlife <dev@fetlife.com>", "Andrii Dmytrenko <refresh.xss@gmail.com
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-magnus = { version="0.7.1", optional = true }
+magnus = { version="0.8.2", optional = true }
 csv = { version = "^1.3", optional = true }
 fnv = "1.0.7"
 indexmap = "2.8.0"
@@ -22,7 +22,7 @@ name = "distributing_iterator"
 crate-type = ["cdylib", "lib"]
 
 [features]
-default = ["ruby_ext"]
+default = ["csv"]
 ruby_ext = ["dep:magnus", "csv"]
 csv = ["dep:csv"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distributing-iterator"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 publish = false
 authors = ["Fetlife <dev@fetlife.com>", "Andrii Dmytrenko <refresh.xss@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ id,name
 3,xyzzy
 CSV
 
-output = DistributingIterator.distribute(csv, 'id', 3)
+output = DistributingIterator.distribute_csv(csv, 'id', 3)
 
 puts output
 # id,name
@@ -93,13 +93,39 @@ puts output
 
 # Releasing a New Version
 
+To work on the gem locally:
+
+```bash
+bundle install
+bundle exec rake compile
+bundle exec rake test
+```
+
+To build a source gem:
+
+```bash
+bundle exec rake build
+```
+
+To build a native gem for the current platform:
+
+```bash
+bundle exec rake native gem
+```
+
+To build a cross-compiled native gem for a specific platform:
+
+```bash
+bundle exec rb-sys-dock --platform x86_64-linux --build
+```
+
 To release a new version of the gem:
 
 1. Update the version number in `Cargo.toml` and `lib/distributing_iterator/version.rb`
-2. Create and push a new git tag with the version number (e.g., `v1.0.0`):
+2. Create and push a new git tag with the version number (e.g., `0.2.1` or `v0.2.1`):
    ```bash
-   git tag 1.0.0
-   git push origin 1.0.0
+   git tag 0.2.1
+   git push origin 0.2.1
    ```
 
 The release workflow will automatically:
@@ -107,7 +133,9 @@ The release workflow will automatically:
 - Compile native gems for multiple platforms:
   - x86_64 Linux
   - aarch64 Linux
+  - x86_64 macOS
   - arm64 macOS
+  - x64 Windows (UCRT)
 - Create a GitHub release with all compiled gems
 - Generate release notes based on the commits since the last release
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,29 +1,21 @@
-require 'rubygems/package_task'
+# frozen_string_literal: true
 
-spec = eval(File.read("distributing_iterator.gemspec"))
-GEM_RUBY_VERSION = "3.3.0"
-DOCKER_IMAGE = "ruby:#{GEM_RUBY_VERSION}-bullseye"
+require "bundler/gem_tasks"
+require "rake/testtask"
+require "rb_sys/extensiontask"
 
-def compile_cmd(_arch)
-  "gem instal gem-compiler; apt-get update && apt-get install -y libclang-dev; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; source '/root/.cargo/env'; rake gem:native"
+GEMSPEC = Gem::Specification.load("distributing_iterator.gemspec")
+
+task default: :test
+task gem: :build
+
+RbSys::ExtensionTask.new("distributing-iterator", GEMSPEC) do |ext|
+  ext.lib_dir = "lib/distributing_iterator"
 end
 
-gem_task = Gem::PackageTask.new(spec) do |pkg|
-  pkg.need_zip = true
-  pkg.need_tar = true
-end
-
-desc "Generate a pre-compiled native gem for #{RUBY_PLATFORM}"
-task "gem:native" => ["gem"] do
-  sh "gem compile #{gem_task.package_dir_path}.gem"
-end
-
-desc "Generate a pre-compiled native gem for aarch64-linux"
-task "gem:native:aarch64-linux" => ["gem"] do
-  sh %{docker run --rm --platform linux/arm64 -v $(pwd):/src -w /src #{DOCKER_IMAGE} /bin/bash -c "#{compile_cmd('aarch64-unknown-linux-musl')}"}
-end
-
-desc "Generate a pre-compiled native gem for x86_64-linux"
-task "gem:native:x86_64-linux" => ["gem"] do
-  sh %{docker run --rm --platform linux/amd64 -v $(pwd):/src -w /src #{DOCKER_IMAGE} /bin/bash -c "#{compile_cmd('x86_64-unknown-linux-musl')}"}
+Rake::TestTask.new do |t|
+  t.deps << "compile:dev"
+  t.libs << "lib"
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
 end

--- a/distributing_iterator.gemspec
+++ b/distributing_iterator.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-compiler", "~> 1.2"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.required_rubygems_version = Gem::Requirement.new(">= 3.4.0") if spec.respond_to? :required_rubygems_version=
 
   spec.metadata = {
     "github_repo" => "ssh://github.com/fetlife/distributing-iterator",

--- a/distributing_iterator.gemspec
+++ b/distributing_iterator.gemspec
@@ -17,20 +17,30 @@ Gem::Specification.new do |spec|
 
   spec.platform = Gem::Platform::RUBY
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir["lib/**/*.rb", "src/**/*.rs", "benches/**/*.rs", ".cargo/*", "Cargo.toml", "Cargo.lock", "README.md", "LICENSE.txt"]
+  spec.files = Dir[
+    "lib/**/*.rb",
+    "ext/**/*",
+    "extconf.rb",
+    "src/**/*.rs",
+    "benches/**/*.rs",
+    ".cargo/*",
+    "Cargo.toml",
+    "Cargo.lock",
+    "README.md",
+    "LICENSE"
+  ]
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.extensions = ["Cargo.toml"]
+  spec.extensions = ["ext/distributing_iterator/extconf.rb"]
+  spec.add_dependency "rb_sys", "~> 0.9"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "gem-compiler"
-  spec.add_development_dependency "ffi"
+  spec.add_development_dependency "rake-compiler", "~> 1.2"
+  spec.add_development_dependency "minitest", "~> 5.0"
   spec.required_rubygems_version = Gem::Requirement.new(">= 3.4.0") if spec.respond_to? :required_rubygems_version=
 
-  spec.metadata = { "github_repo" => "ssh://github.com/fetlife/distributing-iterator" }
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.metadata = {
+    "github_repo" => "ssh://github.com/fetlife/distributing-iterator",
+    "cargo_crate_name" => "distributing-iterator"
+  }
 end

--- a/ext/distributing_iterator/extconf.rb
+++ b/ext/distributing_iterator/extconf.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+load File.expand_path("../../extconf.rb", __dir__)

--- a/extconf.rb
+++ b/extconf.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "mkmf"
+require "rb_sys/mkmf"
+
+create_rust_makefile("distributing_iterator") do |config|
+  config.ext_dir = __dir__
+  config.features = ["ruby_ext"]
+  config.profile = ENV.fetch("RB_SYS_CARGO_PROFILE", "release").to_sym
+end

--- a/lib/distributing_iterator.rb
+++ b/lib/distributing_iterator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "distributing_iterator/version"
+require_relative "distributing_iterator/distributing_iterator"

--- a/lib/distributing_iterator/version.rb
+++ b/lib/distributing_iterator/version.rb
@@ -1,3 +1,3 @@
 module DistributingIterator
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/src/ruby_ext.rs
+++ b/src/ruby_ext.rs
@@ -1,11 +1,11 @@
-use magnus::{error::Result, exception, function, Error};
+use magnus::{error::Result, function, Error, Ruby};
 
 use crate::{distribute_ids, distribute_csv};
 
-fn distribute_csv_ruby(data: String, field: String, spread: u64) -> Result<String> {
+fn distribute_csv_ruby(ruby: &Ruby, data: String, field: String, spread: u64) -> Result<String> {
     match distribute_csv(&data, &field, spread) {
         Ok(result) => Ok(result),
-        Err(e) => Err(Error::new(exception::standard_error(), format!("{:?}", e))),
+        Err(e) => Err(Error::new(ruby.exception_standard_error(), format!("{:?}", e))),
     }
 }
 

--- a/test/distributing_iterator_test.rb
+++ b/test/distributing_iterator_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class DistributingIteratorTest < Minitest::Test
+  def test_distribute_csv
+    csv = <<~CSV
+      id,name
+      1,foo
+      1,bar
+      1,baz
+      2,qux
+      3,quux
+      3,corge
+      2,grault
+      2,garply
+      3,waldo
+      3,fred
+      2,plugh
+      3,xyzzy
+      2,thud
+      3,plugh
+      3,xyzzy
+    CSV
+
+    result = DistributingIterator.distribute_csv(csv, "id", 3)
+
+    assert_equal(
+      "id,name\n1,foo\n2,qux\n3,quux\n1,bar\n2,grault\n3,corge\n1,baz\n2,garply\n3,waldo\n2,plugh\n3,fred\n2,thud\n3,xyzzy\n3,plugh\n3,xyzzy\n",
+      result
+    )
+  end
+
+  def test_distribute_indexes
+    result = DistributingIterator.distribute_indexes(
+      %w[Picture Post Video Video Picture Post Picture Picture Video],
+      3
+    )
+
+    assert_equal [0, 1, 2, 4, 5, 3, 6, 8, 7], result
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "distributing_iterator"


### PR DESCRIPTION
## Summary

- switch the gem from the RubyGems Cargo builder / `gem-compiler` flow to `rb_sys` + `rake-compiler`
- upgrade `magnus` to `0.8.2` and update the Ruby extension code for the current API
- add the standard `rb_sys` extconf setup and a real `require "distributing_iterator"` entrypoint
- split Cargo features so Rust-only `cargo test` no longer builds the Ruby extension by default
- add Ruby smoke tests for `distribute_csv` and `distribute_indexes`
- update CI/release automation to build the source gem and native gems with the new toolchain
- bump the gem/crate version to `0.2.1`
- ignore `Gemfile.lock` for this gem repo

## Details

- added root `extconf.rb` plus `ext/distributing_iterator/extconf.rb` wrapper for gem installation
- replaced custom `gem:native*` tasks with `rb_sys`/`rake-compiler` tasks and a `gem` alias for native packaging
- updated the gemspec dependencies/files to use `rb_sys`, `rake-compiler`, and `minitest`
- updated the release workflow to accept both `vX.Y.Z` and `X.Y.Z` tags and to build cross-platform native gems via `rb-sys-dock`
- updated the README to document the new build/test/release commands

## Testing

- `cargo test`
- `mise exec ruby@3.4 -- bundle exec rake test`
- `mise exec ruby@3.4 -- bundle exec rake build`
- `env CARGO_HOME=/tmp/distributing-iterator-cargo-home mise exec ruby@3.4 -- bundle exec rake native gem`
